### PR TITLE
Avgrens databaseovervåkning til Pod leader

### DIFF
--- a/.nais/nais.yml
+++ b/.nais/nais.yml
@@ -33,6 +33,7 @@ spec:
     requests:
       cpu: 200m
       memory: 256Mi
+  leaderElection: true
   ingresses:
   {{#each ingress}}
     - "{{this}}"

--- a/fillager/pom.xml
+++ b/fillager/pom.xml
@@ -21,6 +21,7 @@
 		<prometheus-client.version>0.16.0</prometheus-client.version>
 		<logstash.version>7.2</logstash.version>
 		<mockk.version>1.13.2</mockk.version>
+		<kotlin-serialization.version>1.4.1</kotlin-serialization.version>
 
 		<maven-surefire-plugin.version>3.0.0-M7</maven-surefire-plugin.version>
 		<kotlin.version>1.7.20</kotlin.version>
@@ -78,6 +79,11 @@
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-kotlin</artifactId>
 			<version>${springdoc.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.jetbrains.kotlinx</groupId>
+			<artifactId>kotlinx-serialization-json</artifactId>
+			<version>${kotlin-serialization.version}</version>
 		</dependency>
 
 
@@ -174,6 +180,7 @@
 					<compilerPlugins>
 						<plugin>spring</plugin>
 						<plugin>jpa</plugin>
+						<plugin>kotlinx-serialization</plugin>
 					</compilerPlugins>
 				</configuration>
 				<dependencies>

--- a/fillager/pom.xml
+++ b/fillager/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
 				 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
@@ -172,6 +172,20 @@
 				<groupId>org.jetbrains.kotlin</groupId>
 				<artifactId>kotlin-maven-plugin</artifactId>
 				<version>${kotlin.version}</version>
+				<executions>
+					<execution>
+						<id>compile</id>
+						<goals>
+							<goal>compile</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>test-compile</id>
+						<goals>
+							<goal>test-compile</goal>
+						</goals>
+					</execution>
+				</executions>
 				<configuration>
 					<nowarn>true</nowarn>
 					<args>
@@ -192,6 +206,11 @@
 					<dependency>
 						<groupId>org.jetbrains.kotlin</groupId>
 						<artifactId>kotlin-maven-noarg</artifactId>
+						<version>${kotlin.version}</version>
+					</dependency>
+					<dependency>
+						<groupId>org.jetbrains.kotlin</groupId>
+						<artifactId>kotlin-maven-serialization</artifactId>
 						<version>${kotlin.version}</version>
 					</dependency>
 				</dependencies>

--- a/fillager/src/main/kotlin/no/nav/soknad/arkivering/soknadsfillager/db/DbSupervision.kt
+++ b/fillager/src/main/kotlin/no/nav/soknad/arkivering/soknadsfillager/db/DbSupervision.kt
@@ -1,5 +1,6 @@
 package no.nav.soknad.arkivering.soknadsfillager.db
 
+import no.nav.soknad.arkivering.soknadsfillager.LeaderSelectionUtility
 import no.nav.soknad.arkivering.soknadsfillager.repository.FilRepository
 import no.nav.soknad.arkivering.soknadsfillager.supervision.FileMetrics
 import org.slf4j.LoggerFactory
@@ -11,7 +12,8 @@ import org.springframework.stereotype.Component
 @EnableScheduling
 class DbSupervision(
 	private val filRepository: FilRepository,
-	private val fileMetrics: FileMetrics
+	private val fileMetrics: FileMetrics,
+	private val leaderSelectionUtility: LeaderSelectionUtility
 ) {
 
 	private val logger = LoggerFactory.getLogger(javaClass)
@@ -19,7 +21,9 @@ class DbSupervision(
 	@Scheduled(cron = everyFiveMinutes)
 	fun databaseSupervisionStart() {
 		try {
-			collectDbStat()
+			if (leaderSelectionUtility.isLeader()) {
+				collectDbStat()
+			}
 		} catch (e: Exception) {
 			logger.error("Something went wrong when performing database supervision", e)
 		}

--- a/fillager/src/main/kotlin/no/nav/soknad/arkivering/soknadsfillager/kubernetes/LeaderElection.kt
+++ b/fillager/src/main/kotlin/no/nav/soknad/arkivering/soknadsfillager/kubernetes/LeaderElection.kt
@@ -1,0 +1,11 @@
+package no.nav.soknad.arkivering.soknadsfillager
+
+import kotlinx.serialization.Serializable
+import java.time.LocalDateTime
+
+@Serializable
+data class LeaderElection(
+	val name: String,
+	val last_update: String? = LocalDateTime.now().toString()
+)
+

--- a/fillager/src/main/kotlin/no/nav/soknad/arkivering/soknadsfillager/kubernetes/LeaderSelectionUtility.kt
+++ b/fillager/src/main/kotlin/no/nav/soknad/arkivering/soknadsfillager/kubernetes/LeaderSelectionUtility.kt
@@ -1,0 +1,42 @@
+package no.nav.soknad.arkivering.soknadsfillager
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import java.net.InetAddress
+import java.net.URL
+
+@Component
+class LeaderSelectionUtility {
+	val logger = LoggerFactory.getLogger(javaClass)
+
+	@OptIn(ExperimentalSerializationApi::class)
+	val format = Json { explicitNulls = false; ignoreUnknownKeys = true }
+
+
+	fun isLeader(): Boolean {
+		val hostname = InetAddress.getLocalHost().hostName
+		val jsonString = fetchLeaderSelection()
+		val leader = format.decodeFromString<LeaderElection>(jsonString).name
+
+		val isLeader = hostname.equals(leader, true)
+		logger.info("isLeader=$isLeader")
+		return isLeader
+	}
+
+	fun fetchLeaderSelection(): String {
+		val electorPath = System.getenv("ELECTOR_PATH") ?: System.getProperty("ELECTOR_PATH")
+		if (electorPath.isNullOrBlank()) {
+			logger.info("ELECTOR_PATH er null eller blank")
+			throw RuntimeException("ELECTOR_PATH er null eller blank")
+		}
+		logger.info("Elector_path=$electorPath")
+		val fullUrl = if (electorPath.contains(":/")) electorPath else "http://$electorPath"
+		val jsonString = URL(fullUrl).readText()
+		logger.info("Elector_path som jsonstring=$jsonString")
+		return jsonString
+	}
+
+}

--- a/fillager/src/test/kotlin/no/nav/soknad/arkivering/soknadsfillager/kubernetes/LeaderSelectionTest.kt
+++ b/fillager/src/test/kotlin/no/nav/soknad/arkivering/soknadsfillager/kubernetes/LeaderSelectionTest.kt
@@ -1,0 +1,46 @@
+package no.nav.soknad.arkivering.soknadsfillager.kubernetes
+
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import no.nav.soknad.arkivering.soknadsfillager.LeaderElection
+import no.nav.soknad.arkivering.soknadsfillager.LeaderSelectionUtility
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+class LeaderSelectionTest {
+
+	@OptIn(ExperimentalSerializationApi::class)
+	val format = Json { explicitNulls = false; ignoreUnknownKeys = true }
+
+	@BeforeEach
+	fun setup() {
+	}
+
+	@AfterEach
+	fun ryddOpp() {
+	}
+
+	@Test
+	fun testLeaderSelection() {
+		val leaderElection = LeaderElection("localhost", LocalDateTime.now().toString())
+		val jsonString = format.encodeToString(leaderElection)
+		System.setProperty("ELECTOR_PATH", "localhost")
+
+		val leaderSelector = mockk<LeaderSelectionUtility>()
+		every { leaderSelector.fetchLeaderSelection() } returns jsonString
+		every { leaderSelector.logger.warn(any()) } returns Unit
+		every { leaderSelector.logger.info(any()) } returns Unit
+		every { leaderSelector.format.decodeFromString<LeaderElection>(any()) } returns leaderElection
+		every { leaderSelector.isLeader() } answers { callOriginal() }
+
+		leaderSelector.isLeader()
+
+	}
+
+}


### PR DESCRIPTION
## Forklaring
I dag overvåker alle soknadsfillager sine podder database størrelsen og oppdaterer metrics for dette. Dette fører til at det vises ett innslag i Grafana for hver POD. Dette bør avgrenses til at bare Pod leader utfører overvåkningen.

Dette testes ved å deploye endringen til dev.

## DoD
I Grafana i boardet for nytt innsendingsløp kun et innslag for søknadsfillagers databasestørrelse

## Screenshots
### Før
![Skjermbilde 2023-02-22 kl  12 07 33](https://user-images.githubusercontent.com/7783861/220603130-05cad48e-8de6-4904-bb37-6392f4ec97f9.png)

### Etter
![Skjermbilde 2023-02-22 kl  12 40 43](https://user-images.githubusercontent.com/7783861/220610099-da23fee9-4abb-441e-8c54-aeaa7d0f5004.png)



